### PR TITLE
Branches/utf8check

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ hanz2piny 的完整命令行选项如下：
 指定输出结果中，替换掉未成功转换拼音的原字符；  
 可选；  
 无参数。  
+--ignore-utf8-check
+跳过文件的utf8合法行检查
+可选； 默认开启检查 
+无参数。  
 --replace-unknown-with  
 输出结果中，用指定的字符串替换掉未成功转换拼音的原字符。若未指定 --replace-unknown，则即便指定 --replace-unknown-with 也无效果；  
 可选；  

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,6 +58,8 @@ showHelpInfo (void)
                     "focus pinyin in non-name, set up noname. The default argument is noname;" << endl;
     cout << endl << "\t--replace-unknown. some char that hanz2piny could not handle, you can replace them by "
                     "set on this option;" << endl;
+    cout << endl << "\t--ignore-utf8-check. don't check if file utf8 valid, default to check"
+                    "set off this option;" << endl;
     cout << endl << "\t--replace-unknown-with. some char that hanz2piny could not handle, you can replace "
                     "them with string by set up this argument; " << endl;
     cout << endl << "\t--path. set up the file path that chinese hanzi file, make sure the file is exist "
@@ -98,10 +100,10 @@ main (int argc, char* argv[])
     }
 
     // --tone
-    const bool tone = cmdline_options.hasOption("--tone"); 
+    const bool tone = cmdline_options.hasOption("--tone");
 
     // --camel
-    const bool camel = cmdline_options.hasOption("--camel"); 
+    const bool camel = cmdline_options.hasOption("--camel");
 
     // --polyphone
     Hanz2Piny::Polyphone polyphone;
@@ -119,7 +121,7 @@ main (int argc, char* argv[])
     }
 
     // --replace-unknown
-    const bool replace_unknown = cmdline_options.hasOption("--replace-unknown"); 
+    const bool replace_unknown = cmdline_options.hasOption("--replace-unknown");
 
     // --replace-unknown-with
     cmdline_arguments_list = cmdline_options.getArgumentsList("--replace-unknown-with");
@@ -137,13 +139,18 @@ main (int argc, char* argv[])
 
 
     const Hanz2Piny hanz2piny;
-    if (!hanz2piny.isUtf8File(file_path)) {
-        cerr << "ERROR! fail to open UTF-8 encoding file " << file_path
-             << ". make sure the file is exist and the encoding is UTF-8. "
-             << endl;
-        exit(EXIT_FAILURE);
+
+    // --checkutf8
+    const bool ignore_utf8_check = cmdline_options.hasOption("--ignore-utf8-check");
+    if (!ignore_utf8_check) {
+        if (!hanz2piny.isUtf8File(file_path)) {
+            cerr << "ERROR! fail to open UTF-8 encoding file " << file_path
+                 << ". make sure the file is exist and the encoding is UTF-8. "
+                 << endl;
+            exit(EXIT_FAILURE);
+        }
     }
-    
+
     ifstream utf8_ifs(file_path);
     string line;
     while (getline(utf8_ifs, line)) {
@@ -151,7 +158,7 @@ main (int argc, char* argv[])
         if (hanz2piny.isStartWithBom(line)) {
             line = string(line.cbegin() + 3, line.cend());
         }
-        
+
         vector<pair<bool, vector<string>>> pinyin_list_list = hanz2piny.toPinyinFromUtf8( line,
                                                                                           tone,
                                                                                           replace_unknown,
@@ -159,7 +166,7 @@ main (int argc, char* argv[])
         for (const auto& e : pinyin_list_list) {
             const bool ok = e.first;
             auto pinyin_list = e.second;
-            
+
             if (pinyin_list.size() == 1) {          // 单音字
                 auto pinyin = pinyin_list[0];
                 if (ok && camel) {
@@ -179,7 +186,7 @@ main (int argc, char* argv[])
                         cout << "\b\b>";
                     }
                     break;
-                    
+
                     case Hanz2Piny::name: {
                         auto pinyin = pinyin_list[0];
                         if (ok && camel) {
@@ -188,7 +195,7 @@ main (int argc, char* argv[])
                         cout << pinyin;
                     }
                     break;
-                    
+
                     case Hanz2Piny::noname: {
                         auto pinyin = pinyin_list[1];
                         if (ok && camel) {


### PR DESCRIPTION
[issue5](https://github.com/yangyangwithgnu/hanz2piny/issues/5):增加一个选项，可以跳过文件的utf-8合法性检查